### PR TITLE
Add ConflictException and enhance lesson validation

### DIFF
--- a/ICEDT.API/Middleware/Exceptions.cs
+++ b/ICEDT.API/Middleware/Exceptions.cs
@@ -19,4 +19,14 @@
     {
         public NotFoundException(string message) : base(message) { }
     }
+
+    public class ConflictException : Exception
+    {
+        public ConflictException() { }
+
+        public ConflictException(string message) : base(message) { }
+
+        public ConflictException(string message, Exception inner) : base(message, inner) { }
+    }
+
 }


### PR DESCRIPTION
Introduced a new `ConflictException` class in `Exceptions.cs` with multiple constructors. Updated `LevelService.cs` to include checks for existing lesson names and sequence orders, throwing `ConflictException` when conflicts arise. Maintained existing validation for level IDs and lesson names, and ensured consistent error handling in `RemoveLessonFromLevelAsync`.